### PR TITLE
adding group_left, group_right capabilities

### DIFF
--- a/src/gleither.gleam
+++ b/src/gleither.gleam
@@ -1,6 +1,6 @@
 import gleam/option.{type Option, None, Some}
 
-/// Monad representing a Left or Right
+/// monad representing a Left or Right
 pub type Either(left, right) {
   /// left
   Left(val: left)
@@ -8,12 +8,12 @@ pub type Either(left, right) {
   Right(val: right)
 }
 
-/// Returns True if the supplied value is a Left
+/// returns True if the supplied value is a Left
 pub fn is_left(either: Either(left, right)) -> Bool {
   !is_right(either)
 }
 
-/// Returns True if the supplied value is a Right
+/// returns True if the supplied value is a Right
 pub fn is_right(either: Either(left, right)) -> Bool {
   case either {
     Left(_) -> False
@@ -169,7 +169,7 @@ pub fn flat_map(
   flat_map_right(either, func)
 }
 
-/// Convert a Left to a Right and vice versa
+/// convert a Left to a Right and vice versa
 pub fn swap(either: Either(left, right)) -> Either(right, left) {
   case either {
     Right(r) -> Left(r)
@@ -177,10 +177,11 @@ pub fn swap(either: Either(left, right)) -> Either(right, left) {
   }
 }
 
-/// Convert a Result to an Either, mapping Ok to Left and Error to Right
+/// convert a Result to an Either, mapping Ok to Left and Error to Right
 pub fn from_result(result: Result(left, right)) -> Either(left, right) {
   case result {
     Ok(l) -> Left(l)
     Error(r) -> Right(r)
   }
 }
+

--- a/src/gleither.gleam
+++ b/src/gleither.gleam
@@ -337,3 +337,34 @@ pub fn map_resolve(
 ) -> List(new) {
   list.map(vals, resolve(_, left_map, right_map))
 }
+
+/// constructs an Either from a value and a Bool by wrapping the value with Left
+/// if the Bool is False, Right if the Bool is True
+pub fn from_bool(
+  val: a,
+  bool: Bool,
+) -> Either(a, a) {
+  case bool {
+    False -> Left(val)
+    True -> Right(val)
+  }
+}
+
+/// constructs an Either from a value val : a and a condition fn(a) -> Bool, 
+/// wrapping the value with Left or Right according to whether the condition evaluates
+/// to False or True, respectively, at the value
+pub fn from_condition(
+  val: a,
+  condition: fn(a) -> Bool,
+) -> Either(a, a) {
+  from_bool(val, condition(val))
+}
+
+/// shorthand to list.map gleither.from_condition over a list of values, creating
+/// a List(Either(a, a)) from a List(a) via a condition: fn(a) -> Bool
+pub fn map_from_condition(
+  vals: List(a),
+  condition: fn(a) -> Bool,
+) -> List(Either(a, a)) {
+  list.map(vals, from_condition(_, condition))
+}

--- a/src/gleither.gleam
+++ b/src/gleither.gleam
@@ -315,3 +315,25 @@ pub fn nonempty_group_right(
     }
   })
 }
+
+/// maps an Either(left, right) value to a value of a third type by applying 
+/// separate Left and Right mappers that both map to the third type
+pub fn resolve(
+  val: Either(left, right),
+  left_map: fn(left) -> new,
+  right_map: fn(right) -> new,
+) -> new {
+  case val {
+    Left(left) -> left_map(left)
+    Right(right) -> right_map(right)
+  }
+}
+
+/// a shorthand to list.map gleither.resolve
+pub fn map_resolve(
+  vals: List(Either(left, right)),
+  left_map: fn(left) -> new,
+  right_map: fn(right) -> new,
+) -> List(new) {
+  list.map(vals, resolve(_, left_map, right_map))
+}

--- a/test/gleither_test.gleam
+++ b/test/gleither_test.gleam
@@ -231,3 +231,24 @@ pub fn map_resolve_test() {
   )
   |> should.equal([2, 0])
 }
+
+pub fn from_bool_test() {
+  gleither.from_bool(1, False)
+  |> should.equal(Left(1))
+
+  gleither.from_bool(1, True)
+  |> should.equal(Right(1))
+}
+
+pub fn from_condition_test() {
+  gleither.from_condition(1, fn(x) { x > 0 })
+  |> should.equal(Right(1))
+
+  gleither.from_condition(0, fn(x) { x > 0 })
+  |> should.equal(Left(0))
+}
+
+pub fn map_from_condition_test() {
+  gleither.map_from_condition([-1, 0, 1, 0], fn(x) { x > 0 })
+  |> should.equal([Left(-1), Left(0), Right(1), Left(0)])
+}

--- a/test/gleither_test.gleam
+++ b/test/gleither_test.gleam
@@ -162,3 +162,47 @@ pub fn from_result_test() {
   |> gleither.from_result()
   |> should.equal(Right(1))
 }
+
+pub fn group_left_test() {
+  gleither.group_left([Left(1), Left(5), Right("a"), Right("b"), Left(6)])
+  |> should.equal([Left([1, 5]), Right("a"), Left([]), Right("b"), Left([6])])
+
+  gleither.group_left([Left(1), Left(5), Right("a"), Right("b")])
+  |> should.equal([Left([1, 5]), Right("a"), Left([]), Right("b"), Left([])])
+
+  gleither.group_left([Right("a"), Right("b")])
+  |> should.equal([Left([]), Right("a"), Left([]), Right("b"), Left([])])
+}
+
+pub fn nonempty_group_left_test() {
+  gleither.nonempty_group_left([Left(1), Left(5), Right("a"), Right("b"), Left(6)])
+  |> should.equal([Left([1, 5]), Right("a"), Right("b"), Left([6])])
+
+  gleither.nonempty_group_left([Left(1), Left(5), Right("a"), Right("b")])
+  |> should.equal([Left([1, 5]), Right("a"), Right("b")])
+
+  gleither.nonempty_group_left([Right("a"), Right("b")])
+  |> should.equal([Right("a"), Right("b")])
+}
+
+pub fn group_right_test() {
+  gleither.group_right([Right(1), Right(5), Left("a"), Left("b"), Right(6)])
+  |> should.equal([Right([1, 5]), Left("a"), Right([]), Left("b"), Right([6])])
+
+  gleither.group_right([Right(1), Right(5), Left("a"), Left("b")])
+  |> should.equal([Right([1, 5]), Left("a"), Right([]), Left("b"), Right([])])
+
+  gleither.group_right([Left("a"), Left("b")])
+  |> should.equal([Right([]), Left("a"), Right([]), Left("b"), Right([])])
+}
+
+pub fn nonempty_group_right_test() {
+  gleither.nonempty_group_right([Right(1), Right(5), Left("a"), Left("b"), Right(6)])
+  |> should.equal([Right([1, 5]), Left("a"), Left("b"), Right([6])])
+
+  gleither.nonempty_group_right([Right(1), Right(5), Left("a"), Left("b")])
+  |> should.equal([Right([1, 5]), Left("a"), Left("b")])
+
+  gleither.nonempty_group_right([Left("a"), Left("b")])
+  |> should.equal([Left("a"), Left("b")])
+}

--- a/test/gleither_test.gleam
+++ b/test/gleither_test.gleam
@@ -206,3 +206,28 @@ pub fn nonempty_group_right_test() {
   gleither.nonempty_group_right([Left("a"), Left("b")])
   |> should.equal([Left("a"), Left("b")])
 }
+
+pub fn resolve_test() {
+  gleither.resolve(
+    Left(1),
+    fn(x) { x + 1 },
+    fn(_) { 0 },
+  )
+  |> should.equal(2)
+
+  gleither.resolve(
+    Right(Nil),
+    fn(x) { x + 1 },
+    fn(_) { 0 },
+  )
+  |> should.equal(0)
+}
+
+pub fn map_resolve_test() {
+  gleither.map_resolve(
+    [Left(1), Right(Nil)],
+    fn(x) { x + 1 },
+    fn(_) { 0 },
+  )
+  |> should.equal([2, 0])
+}


### PR DESCRIPTION
Hi. I was going to write my own but found this one!

The functions I add in this PR are list-related capabilities related to:

- instantiating lists of Either (`map_from_condition`)
- working with lists of Either (`group_left`, `group_right', etc)
- escaping lists of Either (`map_resolve`)

...and some attendant non-List related functions. (`resolve`, `from_bool`)

Thanks!